### PR TITLE
Fix use of PGUSER environment variable in RoundTrip test setup/teardown scripts

### DIFF
--- a/dbptk-core/src/test/resources/postgreSql/scripts/setup.sh
+++ b/dbptk-core/src/test/resources/postgreSql/scripts/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #ARGS:
 # source database name
@@ -7,8 +7,8 @@
 # temporary user password
 
 #ENVIRONMENT VARS:
-# DPT_POSTGRESQL_USER - postgres username for a user with permission to create a new user (defaults to "root")
-# DPT_POSTGRESQL_PASS - postgres password for the DPT_MYSQL_USER user (defaults to empty)
+# DPT_POSTGRESQL_USER - postgres username for a user with permission to create a new user (defaults to "postgres")
+# DPT_POSTGRESQL_PASS - postgres password for the DPT_POSTGRESQL_USER user (defaults to empty)
 
 TEST_DB_SOURCE="$1"
 TEST_DB_TARGET="$2"
@@ -24,7 +24,7 @@ fi
 export PGPASSWORD="$DPT_POSTGRESQL_PASS"
 
 function sql() {
-  psql -q -h 127.0.0.1 -U postgres -d postgres --command="$1"
+  psql -q -h 127.0.0.1 -d postgres --command="$1"
 }
 
 # Create test databases

--- a/dbptk-core/src/test/resources/postgreSql/scripts/teardown.sh
+++ b/dbptk-core/src/test/resources/postgreSql/scripts/teardown.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #ARGS:
 # source database name
@@ -6,8 +6,8 @@
 # temporary user username
 
 #ENVIRONMENT VARS:
-# DPT_MYSQL_USER - mysql username for a user with permission to create a new user (defaults to "root")
-# DPT_MYSQL_PASS - mysql password for the DPT_MYSQL_USER user (defaults to empty)
+# DPT_POSTGRESQL_USER - mysql username for a user with permission to create a new user (defaults to "postgres")
+# DPT_POSTGRESQL_PASS - mysql password for the DPT_POSTGRESQL_USER user (defaults to empty)
 
 TEST_DB_SOURCE="$1"
 TEST_DB_TARGET="$2"
@@ -22,7 +22,7 @@ fi
 export PGPASSWORD="$DPT_POSTGRESQL_PASS"
 
 function sql() {
-  psql -q -h 127.0.0.1 -U postgres -d postgres --command="$1"
+  psql -q -h 127.0.0.1 -d postgres --command="$1"
 }
 
 sql "DROP DATABASE IF EXISTS \"$TEST_DB_SOURCE\";"


### PR DESCRIPTION
Removed hardcoded `postgres` user argument for `psql` command to actually use `PGUSER` environment variable.

In the debugging process I also cleaned up some comments in the script and changed the shebang to best practice.