### PR TITLE
Remove null bytes from strings before insertion on postgreql. 

### DIFF
--- a/dbptk-modules/dbptk-module-postgresql/src/main/java/com/databasepreservation/modules/postgresql/out/PostgreSQLJDBCExportModule.java
+++ b/dbptk-modules/dbptk-module-postgresql/src/main/java/com/databasepreservation/modules/postgresql/out/PostgreSQLJDBCExportModule.java
@@ -310,4 +310,15 @@ public class PostgreSQLJDBCExportModule extends JDBCExportModule {
 
     ps.setArray(index, sqlArray);
   }
+
+@Override
+protected void handleSimpleTypeStringDataCell(String data, PreparedStatement ps, int index, Cell cell,
+  ColumnStructure column) throws SQLException {
+    if (data != null) {
+      data = data.replace("\u0000", "");
+      ps.setString(index, data);
+    } else {
+      ps.setNull(index, Types.VARCHAR);
+    }
+  }
 }


### PR DESCRIPTION
This was found while testing dbptk on a number of SIARD 2.1 archives. Apparently Postgresql is not 100% UTF-8 compliant. 

Ref : https://stackoverflow.com/questions/1347646/postgres-error-on-insert-error-invalid-byte-sequence-for-encoding-utf8-0x0