### PR TITLE
Fix: Original Filename of external lobs at doc indexes

### DIFF
--- a/dbptk-model/src/main/java/com/databasepreservation/model/data/BinaryCell.java
+++ b/dbptk-model/src/main/java/com/databasepreservation/model/data/BinaryCell.java
@@ -139,4 +139,8 @@ public class BinaryCell extends Cell implements InputStreamProvider {
   public String getMimeType() {
     return mimeType;
   }
+
+  public void setFile(String file) {
+    this.file = file;
+  }
 }

--- a/dbptk-modules/dbptk-filter-external-lobs/src/main/java/com/databasepreservation/modules/externalLobs/ExternalLOBSFilter.java
+++ b/dbptk-modules/dbptk-filter-external-lobs/src/main/java/com/databasepreservation/modules/externalLobs/ExternalLOBSFilter.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 
 import com.databasepreservation.managers.ExportModuleContextManager;
 import com.databasepreservation.managers.ModuleConfigurationManager;
+import com.databasepreservation.model.data.BinaryCell;
 import com.databasepreservation.model.data.Cell;
 import com.databasepreservation.model.data.NullCell;
 import com.databasepreservation.model.data.Row;
@@ -167,6 +168,9 @@ public class ExternalLOBSFilter implements DatabaseFilterModule {
               .get(currentTable.getId() + index);
             Cell newCell = getExternalLOBSCellHandler(externalLobsConfiguration).handleCell(cell.getId(),
               simpleCell.getSimpleData());
+            if (newCell instanceof BinaryCell binaryCell) {
+              binaryCell.setFile(simpleCell.getSimpleData());
+            }
             rowCells.set(index, newCell);
           } else {
             reporter.ignored("Cell " + cell.getId(), "reference to external LOB is null");

--- a/dbptk-modules/dbptk-module-siard/src/main/java/com/databasepreservation/modules/siard/out/content/SIARDDKContentExportStrategy.java
+++ b/dbptk-modules/dbptk-module-siard/src/main/java/com/databasepreservation/modules/siard/out/content/SIARDDKContentExportStrategy.java
@@ -20,6 +20,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -365,6 +366,12 @@ public class SIARDDKContentExportStrategy implements ContentExportStrategy {
       ConversionReport report = extractReportFromZip(binaryCell);
       if (report == null) {
         throw new ModuleException().withMessage("Missing conversion_report.json in cell archive.");
+      }
+
+      String fileFromCell = binaryCell.getFile();
+      if (fileFromCell != null) {
+        String filename = FilenameUtils.getName(fileFromCell).stripTrailing();
+        report = report.withOriginalFilename(filename);
       }
 
       List<String> siardPhysicalPaths = new ArrayList<>();

--- a/dbptk-modules/dbptk-module-siard/src/main/java/com/databasepreservation/modules/siard/out/output/SIARDDKDatabaseExportModule.java
+++ b/dbptk-modules/dbptk-module-siard/src/main/java/com/databasepreservation/modules/siard/out/output/SIARDDKDatabaseExportModule.java
@@ -360,8 +360,9 @@ public abstract class SIARDDKDatabaseExportModule extends SIARDExportDefault {
 
             // TODO: Handle multiple files per cell if needed. Currently assumes single file
             // output.
-            Cell newCell = new BinaryCell(cell.getId(), new PathInputStreamProvider(result.zipFile()),
+            BinaryCell newCell = new BinaryCell(cell.getId(), new PathInputStreamProvider(result.zipFile()),
               "application/zip");
+            newCell.setFile(binCell.getFile());
             cells.set(i, newCell);
 
             // Track extracted parts to clean them individually later

--- a/dbptk-modules/dbptk-module-siard/src/main/java/com/databasepreservation/modules/siard/services/conversion/model/report/ConversionReport.java
+++ b/dbptk-modules/dbptk-module-siard/src/main/java/com/databasepreservation/modules/siard/services/conversion/model/report/ConversionReport.java
@@ -19,4 +19,9 @@ public record ConversionReport(@JsonProperty("jobId") String jobId, @JsonPropert
     return new ConversionReport(jobId, status, originalFilename, totalArtifactsProduced, artifacts, errorMessage,
       context);
   }
+
+  public ConversionReport withOriginalFilename(String newFilename) {
+    return new ConversionReport(jobId, status, newFilename, totalArtifactsProduced, artifacts, errorMessage,
+      dbptkContext);
+  }
 }


### PR DESCRIPTION
At the SIARD-DK specifications, converted External LOBs must retain their original filename in `docIndexes`. 

This pull request fixes this issue by replacing incorrect names with the proper original filenames.