### PR TITLE
Fix Access decryption: jackcess-encrypt groupId conflict and missing CodecProvider wiring

### DIFF
--- a/dbptk-modules/dbptk-module-ms-access/pom.xml
+++ b/dbptk-modules/dbptk-module-ms-access/pom.xml
@@ -29,12 +29,12 @@
         <dependency>
             <groupId>io.github.spannm</groupId>
             <artifactId>ucanaccess</artifactId>
-            <version>5.1.7</version>
+            <version>5.1.8</version>
         </dependency>
         <dependency>
             <groupId>io.github.spannm</groupId>
             <artifactId>jackcess-encrypt</artifactId>
-            <version>5.1.5</version>
+            <version>5.1.6</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/dbptk-modules/dbptk-module-ms-access/pom.xml
+++ b/dbptk-modules/dbptk-module-ms-access/pom.xml
@@ -29,12 +29,12 @@
         <dependency>
             <groupId>io.github.spannm</groupId>
             <artifactId>ucanaccess</artifactId>
-            <version>5.1.3</version>
+            <version>5.1.7</version>
         </dependency>
         <dependency>
-            <groupId>com.healthmarketscience.jackcess</groupId>
+            <groupId>io.github.spannm</groupId>
             <artifactId>jackcess-encrypt</artifactId>
-            <version>4.0.3</version>
+            <version>5.1.5</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/dbptk-modules/dbptk-module-ms-access/src/main/java/com/databasepreservation/modules/msAccess/MsAccessUCanAccessModuleFactory.java
+++ b/dbptk-modules/dbptk-module-ms-access/src/main/java/com/databasepreservation/modules/msAccess/MsAccessUCanAccessModuleFactory.java
@@ -85,7 +85,8 @@ public class MsAccessUCanAccessModuleFactory implements DatabaseModuleFactory {
   }
 
   @Override
-  public DatabaseImportModule buildImportModule(Map<Parameter, String> parameters, Reporter reporter) throws ModuleException {
+  public DatabaseImportModule buildImportModule(Map<Parameter, String> parameters, Reporter reporter)
+    throws ModuleException {
     String pAccessFilePath = parameters.get(accessFilePath);
 
     String pAccessPassword = null;

--- a/dbptk-modules/dbptk-module-ms-access/src/main/java/com/databasepreservation/modules/msAccess/in/MsAccessCryptCodecJackcessOpener.java
+++ b/dbptk-modules/dbptk-module-ms-access/src/main/java/com/databasepreservation/modules/msAccess/in/MsAccessCryptCodecJackcessOpener.java
@@ -1,0 +1,58 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE file at the root of the source
+ * tree and available online at
+ *
+ * https://github.com/keeps/db-preservation-toolkit
+ */
+package com.databasepreservation.modules.msAccess.in;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import org.apache.commons.lang3.StringUtils;
+
+import io.github.spannm.jackcess.Database;
+import io.github.spannm.jackcess.DatabaseBuilder;
+import io.github.spannm.jackcess.DateTimeType;
+import io.github.spannm.jackcess.encrypt.CryptCodecProvider;
+import net.ucanaccess.jdbc.IJackcessOpenerInterface;
+
+/**
+ * {@link IJackcessOpenerInterface} implementation that registers a
+ * {@link CryptCodecProvider} so that password-protected Microsoft Access
+ * databases (including the AES-encrypted format used by Access 2007+
+ * {@code .accdb} files) can actually be decoded. UCanAccess itself never wires
+ * up {@code jackcess-encrypt}, so without a custom opener like this one, any
+ * password passed to UCanAccess is silently ignored.
+ */
+public class MsAccessCryptCodecJackcessOpener implements IJackcessOpenerInterface {
+
+  @Override
+  public Database open(File fl, String pwd) throws IOException {
+    return open(fl, pwd, null);
+  }
+
+  @Override
+  public Database open(File fl, String pwd, Charset charset) throws IOException {
+    DatabaseBuilder dbd = new DatabaseBuilder()
+      .withFile(fl)
+      .withAutoSync(false)
+      .withCharset(charset);
+
+    if (StringUtils.isNotEmpty(pwd)) {
+      dbd.withCodecProvider(new CryptCodecProvider(pwd));
+    }
+
+    Database db;
+    try {
+      db = dbd.withReadOnly(false).open();
+    } catch (Exception ex) {
+      db = dbd.withReadOnly(true).open();
+    }
+    db.setDateTimeType(DateTimeType.LOCAL_DATE_TIME);
+    return db;
+  }
+
+}

--- a/dbptk-modules/dbptk-module-ms-access/src/main/java/com/databasepreservation/modules/msAccess/in/MsAccessUCanAccessImportModule.java
+++ b/dbptk-modules/dbptk-module-ms-access/src/main/java/com/databasepreservation/modules/msAccess/in/MsAccessUCanAccessImportModule.java
@@ -63,13 +63,13 @@ public class MsAccessUCanAccessImportModule extends JDBCImportModule {
     super("net.ucanaccess.jdbc.UcanaccessDriver",
       "jdbc:ucanaccess://" + msAccessFile.getAbsolutePath() + ";showSchema=true;", new MsAccessHelper(),
       new MsAccessUCanAccessDatatypeImporter(), moduleName, properties);
-      this.msAccessFile = msAccessFile;
+    this.msAccessFile = msAccessFile;
   }
 
   public MsAccessUCanAccessImportModule(String moduleName, File msAccessFile, String password) throws ModuleException {
     this(moduleName, msAccessFile, MapUtils.buildMapFromObjects(MsAccessUCanAccessModuleFactory.PARAMETER_FILE,
       msAccessFile, MsAccessUCanAccessModuleFactory.PARAMETER_PASSWORD, password));
-      this.password = password;
+    this.password = password;
   }
 
   public MsAccessUCanAccessImportModule(String moduleName, String accessFilePath) throws ModuleException {
@@ -84,10 +84,12 @@ public class MsAccessUCanAccessImportModule extends JDBCImportModule {
 
   @Override
   protected Connection createConnection() throws ModuleException {
-     UcanaccessConnectionBuilder builder = new UcanaccessConnectionBuilder().withDbPath(msAccessFile).withProp(Property.showSchema, true);
-     if (StringUtils.isNotEmpty(password)) {
-       builder.withPassword(password);
-     } 
+    UcanaccessConnectionBuilder builder = new UcanaccessConnectionBuilder().withDbPath(msAccessFile).withProp(
+      Property.showSchema, true);
+    if (StringUtils.isNotEmpty(password)) {
+      builder.withPassword(password);
+      builder.withProp(Property.jackcessOpener, MsAccessCryptCodecJackcessOpener.class.getName());
+    }
     return builder.build();
   }
 


### PR DESCRIPTION
## Summary
- UCanAccess (`io.github.spannm`) now depends on `io.github.spannm:jackcess` instead of `com.healthmarketscience.jackcess:jackcess`. The module's `jackcess-encrypt` dependency still pointed at the old `com.healthmarketscience.jackcess` groupId, pulling in a second, incompatible jackcess jar. Switched to the matching `io.github.spannm:jackcess-encrypt` artifact and bumped both dependencies to their latest compatible releases (ucanaccess 5.1.8, jackcess-encrypt 5.1.6, both built against jackcess 5.1.7).
- UCanAccess only forwards the password given to `withPassword()` to the active `IJackcessOpenerInterface` implementation; it never registers a `CodecProvider` itself. Relying on UCanAccess's `DefaultJackcessOpener` meant the password was accepted but silently dropped for AES-encrypted (Access 2007+) databases — `jackcess-encrypt` was a dependency but never actually invoked. Added `MsAccessCryptCodecJackcessOpener`, an `IJackcessOpenerInterface` implementation that wires the password into a `jackcess-encrypt` `CryptCodecProvider`, registered via the `jackcessOpener` connection property whenever a password is supplied.

## Test plan
- [x] `mvn -pl dbptk-modules/dbptk-module-ms-access -am clean install` succeeds against the updated dependencies
- [ ] Manual verification: import a password-protected Access 2007+ (.accdb, AES-encrypted) database with a password and confirm the data is actually decoded (not silently empty/failing)